### PR TITLE
Consumer implementation for KafkaPHP

### DIFF
--- a/src/MessageBroker/ApacheKafka/KafkaPHP/KafkaPHPConsumerAdapter.php
+++ b/src/MessageBroker/ApacheKafka/KafkaPHP/KafkaPHPConsumerAdapter.php
@@ -74,7 +74,7 @@ class KafkaPHPConsumerAdapter implements ConsumerInterface
 
         $messages = $this->fetch();
 
-        $this->offset += count($messages);
+        $this->offset += $messages->count();
 
         return $messages;
     }

--- a/src/MessageBroker/ApacheKafka/KafkaPHP/KafkaPHPConsumerAdapter.php
+++ b/src/MessageBroker/ApacheKafka/KafkaPHP/KafkaPHPConsumerAdapter.php
@@ -7,17 +7,49 @@ use HelloFresh\Reagieren\Message;
 use HelloFresh\Reagieren\ConsumerInterface;
 use HelloFresh\Reagieren\MessageCollection;
 
+/**
+ * Class KafkaPHPConsumerAdapter
+ * @package HelloFresh\Reagieren\MessageBroker\ApacheKafka\KafkaPHP
+ */
 class KafkaPHPConsumerAdapter implements ConsumerInterface
 {
+    /**
+     * @var Consumer
+     */
     private $consumer;
+
+    /**
+     * @var string
+     */
     private $topic;
+
+    /**
+     * @var int|null
+     */
     private $offset;
 
+    /**
+     * Default group to try if none specified
+     */
     const DEFAULT_GROUP = 'reagieren';
-    const DEFAULT_OFFSET = 0;
-    const DEFAULT_PARTITION = 'reagieren';
-    const DEFAULT_POLL_TIMER = 0;
 
+    /**
+     * Default offset to try if none specified
+     */
+    const DEFAULT_OFFSET = 0;
+
+    /**
+     * Default partition to try if none specified
+     */
+    const DEFAULT_PARTITION = 'reagieren';
+
+
+    /**
+     * KafkaPHPConsumerAdapter constructor.
+     * @param     $zookeeperHost
+     * @param int $zookeeperPort
+     * @param int $zookeeperTimeout
+     */
     public function __construct($zookeeperHost, $zookeeperPort = 2181, $zookeeperTimeout = 3000)
     {
         $this->consumer = Consumer::getInstance("$zookeeperHost:$zookeeperPort", $zookeeperTimeout);
@@ -47,6 +79,11 @@ class KafkaPHPConsumerAdapter implements ConsumerInterface
         return $messages;
     }
 
+    /**
+     * Fetch the new messages from the queue
+     *
+     * @return MessageCollection
+     */
     private function fetch()
     {
         $response = $this->consumer->fetch();

--- a/src/MessageBroker/ApacheKafka/KafkaPHP/KafkaPHPConsumerAdapter.php
+++ b/src/MessageBroker/ApacheKafka/KafkaPHP/KafkaPHPConsumerAdapter.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace HelloFresh\Reagieren\MessageBroker\ApacheKafka\KafkaPHP;
+
+use Kafka\Consumer;
+use HelloFresh\Reagieren\Message;
+use HelloFresh\Reagieren\ConsumerInterface;
+use HelloFresh\Reagieren\MessageCollection;
+
+class KafkaPHPConsumerAdapter implements ConsumerInterface
+{
+    private $consumer;
+    private $topic;
+    private $offset;
+
+    const DEFAULT_GROUP = 'reagieren';
+    const DEFAULT_OFFSET = 0;
+    const DEFAULT_PARTITION = 'reagieren';
+    const DEFAULT_POLL_TIMER = 0;
+
+    public function __construct($zookeeperHost, $zookeeperPort = 2181, $zookeeperTimeout = 3000)
+    {
+        $this->consumer = Consumer::getInstance("$zookeeperHost:$zookeeperPort", $zookeeperTimeout);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function consume($topic, $offset = null, $count = 0, $configs = [])
+    {
+        if (null === $this->offset) {
+            $this->offset = null === $offset ? self::DEFAULT_OFFSET : $offset;
+        }
+
+        $group     = isset($configs['group']) ? $configs['group'] : self::DEFAULT_GROUP;
+        $partition = isset($configs['partition']) ? $configs['partition'] : self::DEFAULT_PARTITION;
+
+        $this->consumer->setGroup($group);
+        $this->consumer->setPartition($topic, $partition, $this->offset);
+        $this->topic = $topic;
+        $this->consumer->setTopic($topic, $this->offset);
+
+        $messages = $this->fetch();
+
+        $this->offset += count($messages);
+
+        return $messages;
+    }
+
+    private function fetch()
+    {
+        $response = $this->consumer->fetch();
+
+        $messages = new MessageCollection;
+
+        foreach ($response as $topic => $partition) {
+            if ($topic !== $this->topic) {
+                continue;
+            }
+
+            foreach ($partition as $messageSet) {
+                foreach ($messageSet as $message) {
+                    // yield new Message($message);
+                    $messages->add(new Message($message->getMessage()));
+                }
+            }
+        }
+
+        return $messages;
+    }
+}

--- a/src/MessageBroker/ApacheKafka/KafkaPHP/KafkaPHPProducerAdapter.php
+++ b/src/MessageBroker/ApacheKafka/KafkaPHP/KafkaPHPProducerAdapter.php
@@ -33,6 +33,7 @@ class KafkaPHPProducerAdapter implements ProducerInterface
     public function produce($topic, $payload, $configs = [])
     {
         $partition = $this->choosePartition(
+            $this->producer->getAvailablePartitions($topic),
             $topic,
             isset($configs['partition_strategy']) ? $configs['partition_strategy'] : self::PARTITION_STRATEGY_RANDOM
         );
@@ -67,10 +68,9 @@ class KafkaPHPProducerAdapter implements ProducerInterface
      * @throws ProducerException
      * @return mixed
      */
-    private function choosePartition($topic, $strategy)
+    private function choosePartition($partitions, $topic, $strategy)
     {
         $name = 'partitionStrategy' . ucfirst($strategy);
-        $partitions = $this->producer->getAvailablePartitions($topic);
 
         if (count($partitions) === 0) {
             throw new ProducerException(sprintf(

--- a/src/MessageBroker/ApacheKafka/RdKafka/RdKafkaConsumerAdapter.php
+++ b/src/MessageBroker/ApacheKafka/RdKafka/RdKafkaConsumerAdapter.php
@@ -57,7 +57,7 @@ class RdKafkaConsumerAdapter implements ConsumerInterface
             throw new ConsumerException($message->errstr());
         }
 
-        return new Message($message->payload);
+        return new MessageCollection(new Message($message->payload));
     }
 
     /**

--- a/src/MessageCollection.php
+++ b/src/MessageCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace HelloFresh\Reagieren;
+
+use Collections\ArrayList;
+
+final class MessageCollection extends ArrayList
+{
+
+}


### PR DESCRIPTION
I'm not sure if this is a Kafka-specific thing that just happens to be different to other brokers, but the messages don't seem to be removed from the queue after they've been read?

This means that if you cancel and restart the consumer you get some of the same messages again...
