### PR TITLE
Implements isConnected for producers

### DIFF
--- a/src/MessageBroker/ApacheKafka/RdKafka/Producer.php
+++ b/src/MessageBroker/ApacheKafka/RdKafka/Producer.php
@@ -39,4 +39,16 @@ class Producer implements ProducerInterface
     {
         return 'rd_kafka';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isConnected()
+    {
+        if (!isset($this->producer) || $this->producer->getOutQLen() < 0) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/MessageBroker/RabbitMQ/PHPAmqp/Producer.php
+++ b/src/MessageBroker/RabbitMQ/PHPAmqp/Producer.php
@@ -38,10 +38,10 @@ class Producer extends AbstractAMPQAdapter implements ProducerInterface
 
         $this->connection = new AMQPStreamConnection($host, $port, $username, $password);
         $this->channels = new ArrayList([
-            $this->connection->channel()
+            $this->connection->channel(),
         ]);
     }
-    
+
     /**
      * @return bool
      */
@@ -50,9 +50,9 @@ class Producer extends AbstractAMPQAdapter implements ProducerInterface
         if (!isset($this->connection)) {
             return false;
         }
-        
+
         return $this->connection->isConnected();
-    }    
+    }
 
     /**
      * {@inheritdoc}
@@ -80,7 +80,6 @@ class Producer extends AbstractAMPQAdapter implements ProducerInterface
             $topic
         );
     }
-
 
     /**
      * {@inheritdoc}

--- a/src/MessageBroker/RabbitMQ/PHPAmqp/Producer.php
+++ b/src/MessageBroker/RabbitMQ/PHPAmqp/Producer.php
@@ -43,7 +43,7 @@ class Producer extends AbstractAMPQAdapter implements ProducerInterface
     }
 
     /**
-     * @return bool
+     * {@inheritdoc}
      */
     public function isConnected()
     {

--- a/src/ProducerInterface.php
+++ b/src/ProducerInterface.php
@@ -17,4 +17,9 @@ interface ProducerInterface
      * @return string
      */
     public function getName();
+
+    /**
+     * @return bool
+     */
+    public function isConnected();
 }


### PR DESCRIPTION
Since we are adding `isConnected` to the interface we have to implement it to every producer (see: https://github.com/hellofresh/reagieren/pull/23).
Still missing the implementation for KafkaPHP, didn't quite get an idea of how to do it.
